### PR TITLE
A bug fix for mkIntRep, when rounding the fraction up.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for Posit Numbers
 
+# posit-3.2.0.5
+
+  * Bug fix for `mkIntRep` to resolve an overflow issue with the fractional part when it rounds up, in anticipation of the 2022 Standard release
+
 # posit-3.2.0.4
 
   * No more Orphan Instances for Storable!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# posit 3.2.0.4
+# posit 3.2.0.5
 
 The [Posit Standard 3.2](https://posithub.org/docs/posit_standard.pdf),
 where Real numbers are approximated by Maybe Rational.  The Posit 

--- a/posit.cabal
+++ b/posit.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           posit
-version:        3.2.0.4
+version:        3.2.0.5
 description:    The Posit Number format.  Please see the README on GitHub at <https://github.com/waivio/posit#readme>
 homepage:       https://github.com/waivio/posit#readme
 bug-reports:    https://github.com/waivio/posit/issues

--- a/src/Posit/Internal/PositC.hs
+++ b/src/Posit/Internal/PositC.hs
@@ -1,7 +1,7 @@
 
 --------------------------------------------------------------------------------------------
 --
---   Copyright   :  (C) 2022 Nathan Waivio
+--   Copyright   :  (C) 2022-2023 Nathan Waivio
 --   License     :  BSD3
 --   Maintainer  :  Nathan Waivio <nathan.waivio@gmail.com>
 --   Stability   :  Stable
@@ -54,7 +54,7 @@ import Foreign.Ptr (Ptr, plusPtr, castPtr)  -- Used for dealing with Pointers fo
 import Data.Int (Int8,Int16,Int32,Int64)  -- Import standard Int sizes
 import Data.DoubleWord (Word128,Int128,Int256,fromHiAndLo,hiWord,loWord,DoubleWord,BinaryWord) -- Import large Int sizes
 import Data.Word (Word64)
-import Data.Bits (Bits(..), (.|.), shiftL, shift, testBit, (.&.), shiftR,FiniteBits)
+import Data.Bits (Bits(..), shiftL, shift, testBit, (.&.), shiftR,FiniteBits)
 
 -- Import Naturals and Rationals
 {-@ embed Natural * as int @-}
@@ -227,7 +227,9 @@ class (FixedWidthInteger (IntN es)) => PositC (es :: ES) where
     let (regime', offset) = formRegime @es regime  -- offset is the number of binary digits remaining after the regime is formed
         (exponent', offset') = formExponent @es exponent offset  -- offset' is the number of binary digits remaining after the exponent is formed
         fraction = formFraction @es significand offset'
-    in regime' .|. exponent' .|. fraction
+    in regime' + exponent' + fraction  --  Previously bad code...
+    -- Was previously Bitwise OR'd (regime' .|. exponent' .|. fraction), but that failed when an overflow occurs in the fraction:
+    -- (R @es (6546781215792283740026379393655198304433284092086129578966582736192267592809066457889108741457440782093636999212155773298525238592782299216095867171579 % 6546781215792283740026379393655198304433284092086129578966582736192267592809349109766540184651808314301773368255120142018434513091770786106657055178752))
   
   formRegime :: Integer -> (IntN es, Integer)
   formRegime power

--- a/test/TestPosit.hs
+++ b/test/TestPosit.hs
@@ -1,7 +1,7 @@
 
 --------------------------------------------------------------------------------------------
 -- | Posit Numbers
---   Copyright   :  (C) 2022 Nathan Waivio
+--   Copyright   :  (C) 2022-2023 Nathan Waivio
 --   License     :  BSD3
 --   Maintainer  :  Nathan Waivio <nathan.waivio@gmail.com>
 --   Stability   :  Stable
@@ -11,23 +11,28 @@
 -- 
 ---------------------------------------------------------------------------------------------
 
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
 import Posit
 import Posit.Internal.PositC
 
+import Data.Ratio ((%))  -- Import the Rational Numbers ℚ (u+211A), ℚ can get arbitrarily close to Real numbers ℝ (u+211D), used for some of the Transcendental Functions
 
 
 main :: IO ()
 main = do
 --
-  print $ "exp(1)**(pi*sqrt 43): " ++ show (exp(1 :: Posit256) ** (pi * sqrt 43)) -- 
-  print $ "exp(1)**(pi*sqrt 67): " ++ show (exp(1 :: Posit256) ** (pi * sqrt 67)) -- 
-  print $ "exp(1)**(pi*sqrt 163): " ++ show (exp(1 :: Posit256) ** (pi * sqrt 163)) --
-  print $ "Machine Alpha Posit8 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit8)) -- succ (Posit int) = Posit (succ int)
-  print $ "Machine Alpha Posit16 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit16)) -- 
-  print $ "Machine Alpha Posit32 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit32)) -- 
-  print $ "Machine Alpha Posit64 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit64)) -- 
-  print $ "Machine Alpha Posit128 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit128)) -- 
-  print $ "Machine Alpha Posit256 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit256)) -- 
+  print $ "bitwise OR causes problem when fraction overflows Posit256: should be close to 1.0 not 0.5  ==>  " ++ show (R @V (6546781215792283740026379393655198304433284092086129578966582736192267592809066457889108741457440782093636999212155773298525238592782299216095867171579 % 6546781215792283740026379393655198304433284092086129578966582736192267592809349109766540184651808314301773368255120142018434513091770786106657055178752))
+  print $ "exp(1)**(pi*sqrt 43) :: Posit256 " ++ show (exp(1 :: Posit256) ** (pi * sqrt 43)) -- 
+  print $ "exp(1)**(pi*sqrt 67) :: Posit256 " ++ show (exp(1 :: Posit256) ** (pi * sqrt 67)) -- 
+  print $ "exp(1)**(pi*sqrt 163) :: Posit256 " ++ show (exp(1 :: Posit256) ** (pi * sqrt 163)) --
+  print $ "Machine epsilon Posit8 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit8)) -- succ (Posit int) = Posit (succ int)
+  print $ "Machine epsilon Posit16 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit16)) -- 
+  print $ "Machine epsilon Posit32 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit32)) -- 
+  print $ "Machine epsilon Posit64 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit64)) -- 
+  print $ "Machine epsilon Posit128 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit128)) -- 
+  print $ "Machine epsilon Posit256 ~1.0: " ++ show (1.0 - succ (1.0 :: Posit256)) -- 
   print $ "Does (1 - 1) == 0 ?: " ++ show ((1 - 1) == (0 :: Posit256)) -- [(1 - 1) == zero | zero = 0 :: Posit es, es <- Z .. V]
   let sqrtTaylor = (funLogDomainReduction funLogTaylor).(/2).(funExp2 funExpTaylor).(/log 2)
   print $ "sqrt phi using a Taylor algorithm: " ++ show (sqrtTaylor phi)


### PR DESCRIPTION
So I modified `mkIntRep` from:
`regime' .|. exponent' .|. fraction`
to:
`regime' + exponent' + fraction`
I found that for a specific input the output would be incorrect:
For instance:
`(R @es (6546781215792283740026379393655198304433284092086129578966582736192267592809066457889108741457440782093636999212155773298525238592782299216095867171579 % 6546781215792283740026379393655198304433284092086129578966582736192267592809349109766540184651808314301773368255120142018434513091770786106657055178752))`
Would generate `0.5` instead of `1.0`

This change seems to fix the issue.  Also added a minimal reproducing test to the test suite.
