### PR TITLE
Minor update to add Random, Uniform, and hypot

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for Posit Numbers
 
+# posit-2022.0.1.0
+
+  * Added Random and Uniform Instances
+  * `Uniform` provides a uniform distribution over all possible posits, sampling the entire projective real line
+  * `Random` provides a uniform distribution between 0 and 1, sampling the real numbers in that range
+  * Example: take 10 (randomRs (1,100) (mkStdGen 2023)) :: [Posit64]
+  * Added `hypot2`, `hypot3`, `hypot4`, to the `AltFloating` class
+
 # posit-2022.0.0.1
 
   * Added `PositF` constraint synonym to simplify the usage of `(PositC es, PositC (Next es))`, as is needed for `Floating` instances

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# posit 2022.0.0.1
+# posit 2022.0.1.0
 
 The [Posit Standard 2022](https://posithub.org/docs/posit_standard-2.pdf),
 and [Posit Standard 3.2](https://posithub.org/docs/posit_standard.pdf), 
@@ -21,6 +21,8 @@ the following standard classes:
  * AltShow
  * Read
  * Storable  -- Formats for binary data, for computation and data interchange
+ * Random
+ * Uniform
  * RealFrac
  * RealFloat
  * Floating  -- Mathematical functions such as logarithm, exponential, trigonometric, and hyperbolic functions. Warning! May induce trance.
@@ -54,6 +56,9 @@ class AltFloating p where
   gamma :: p -> p
   sinc :: p -> p
   expm1 :: p -> p
+  hypot2 :: p -> p -> p
+  hypot3 :: p -> p -> p -> p
+  hypot4 :: p -> p -> p -> p -> p
 ```
 
 ```

--- a/posit.cabal
+++ b/posit.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
 name:           posit
-version:        2022.0.0.1
+version:        2022.0.1.0
 description:    The Posit Number format attempting to conform to the Posit Standard Versions 3.2 and 2022.  Where Real numbers are approximated by `Maybe Rational` and sampled in a similar way to the projective real line.
 homepage:       https://github.com/waivio/posit#readme
 bug-reports:    https://github.com/waivio/posit/issues
 author:         Nathan Waivio
 maintainer:     nathan.waivio@gmail.com
-copyright:      2021-2022 Nathan Waivio
+copyright:      2021-2023 Nathan Waivio
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
@@ -26,8 +26,8 @@ source-repository head
   type: git
   location: https://github.com/waivio/posit
 
-flag do-no-storable
-  description: Build without Storable Class support
+flag do-no-storable-random
+  description: Build without Storable or Random/Uniform Class support
   manual:      True
   default:     False
 
@@ -54,11 +54,11 @@ library
   if flag(do-liquid)
     ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--fast -fplugin-opt=LiquidHaskell:--no-termination -fplugin-opt=LiquidHaskell:--max-case-expand=4 -fplugin-opt=LiquidHaskell:--short-names
  
-  if flag(do-no-storable)
-    cpp-options: -DO_NO_STORABLE
+  if flag(do-no-storable-random)
+    cpp-options: -DO_NO_STORABLE_RANDOM
  
   if flag(do-liquid)
-    cpp-options: -DO_LIQUID -DO_NO_STORABLE
+    cpp-options: -DO_LIQUID -DO_NO_STORABLE_RANDOM
  
  
   -- Other library packages from which modules are imported.
@@ -68,6 +68,10 @@ library
   if !flag(do-liquid)
     build-depends:
       base >=4.7 && <5
+ 
+  if !flag(do-no-storable-random)
+    build-depends:
+      random
  
   if flag(do-liquid)
     build-depends:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,9 @@
 # This file is attempting to maintain the working Liquid Haskell versions
 # that coorispond to a specific GHC or Stackage version
 
-# resolver: nightly-2023-03-30  # nightly-2023-02-20 # ghc-9.4.4
-resolver: lts-20.16 # ghc-9.2.7 # Currently the only version that seems to work with LiquidHaskell
-# resolver: lts-19.33 # ghc-9.0.2
+# resolver: nightly-2023-05-20  # ghc-9.4.5
+# resolver: lts-20.21 # ghc-9.2.7
+resolver: lts-19.33 # ghc-9.0.2
 # resolver: lts-18.28 # ghc-8.10.7
 # resolver: lts-18.6 # ghc-8.10.4 
 # resolver: lts-16.31 # ghc-8.8.4 # Fails To Build! ghc: panic! (the 'impossible' happened)
@@ -24,8 +24,8 @@ extra-deps:
   - smtlib-backends-process-0.3 # ghc-9.2.7
   - git: https://github.com/ucsd-progsys/liquidhaskell 
     # commit: <something> # ghc-9.4.4 "Generically" errors out! Ambiguous occurrence ‘Generically’: It could refer to... ‘GHC.Generics.Generically’ or 'Language.Haskell.Liquid.Types.Generics.Generically'
-    commit: 63337d432b47c1ba1ec9925db0994fc5cdce3eaf # ghc-9.2.7
-    # commit: b8780ee8d73d123adb39675ef87a2883f8aa1ecd # ghc-9.0.2
+    # commit: 63337d432b47c1ba1ec9925db0994fc5cdce3eaf # ghc-9.2.7
+    commit: b8780ee8d73d123adb39675ef87a2883f8aa1ecd # ghc-9.0.2
     # commit: f917323a1f9db1677e592d6ffc81467d53588d70 # ghc-8.10.7
     subdirs:
       - .
@@ -35,6 +35,6 @@ extra-deps:
       - liquid-containers
       - liquid-ghc-prim 
   - git: https://github.com/ucsd-progsys/liquid-fixpoint
-    commit: 0e1a4725793740f495c26957044c56488d6e1efc # ghc-9.2.7
-    # commit: 5aed39ec3210b9093ed635693d01bf351e25392f # ghc-9.0.2
+    # commit: 0e1a4725793740f495c26957044c56488d6e1efc # ghc-9.2.7
+    commit: 5aed39ec3210b9093ed635693d01bf351e25392f # ghc-9.0.2
     # commit: 544f8b0ba6d03b060701961250cce012412039c4 # ghc-8.10.7

--- a/test/TestPosit.hs
+++ b/test/TestPosit.hs
@@ -62,7 +62,6 @@ main = do
   print $ "exp(1)**(pi*sqrt 163) :: P16 " ++ show (exp(1 :: P16) ** (pi * sqrt 163)) -- 
   print $ "exp(1)**(pi*sqrt 163) :: Posit8 " ++ show (exp(1 :: Posit8) ** (pi * sqrt 163)) -- 
   print $ "exp(1)**(pi*sqrt 163) :: P8 " ++ show (exp(1 :: P8) ** (pi * sqrt 163)) -- 
-  print $ "Inverse Posit Density Function: :: Posit256 , hmmm well If I could have a function to convert from different distribution funcitons"
 -- | 'EPS'
   print $ "Machine epsilon Posit8 ~1.0: " ++ show (eps :: Posit8) -- succ (Posit int) = Posit (succ int)
   print $ "Machine epsilon Posit16 ~1.0: " ++ show (eps :: Posit16) -- 


### PR DESCRIPTION
Random adds support for a sampling of the real numbers between [0,1).
Uniform adds a uniform sampling of the projective real numbers of all possible posit values.
Added `hypot2`, `hypot3`, `hypot4` to the `AltFloating` class.