### PR TITLE
Natural replacement and Parallel Test Updates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for Posit Numbers
 
-# posit-2022.0.0.1
+# posit-2022.2.0.1
 
  * Converted the function tests to run concurently for a noice speed up
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for Posit Numbers
 
+# posit-2022.0.0.1
+
+ * Converted the function tests to run concurently for a noice speed up
+
 # posit-2022.2.0.0
 
   * Updated divide (/) to have one less round operation, previous default was `a * recip b`, divide two rational numbers then round `viaRational2 (/) a b`, it sort of fuses the old default, reducing error

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 # posit-2022.2.0.1
 
+ * Replaced GHC.Natural with Numeric.Natural
  * Converted the function tests to run concurently for a noice speed up
 
 # posit-2022.2.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright Nathan Waivio (c) 2021-2022
+Copyright Nathan Waivio (c) 2021-2024
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# posit 2022.2.0.0
+# posit 2022.2.0.1
 
 The [Posit Standard 2022](https://posithub.org/docs/posit_standard-2.pdf),
 and [Posit Standard 3.2](https://posithub.org/docs/posit_standard.pdf), 

--- a/posit.cabal
+++ b/posit.cabal
@@ -8,7 +8,7 @@ homepage:       https://github.com/waivio/posit#readme
 bug-reports:    https://github.com/waivio/posit/issues
 author:         Nathan Waivio
 maintainer:     nathan.waivio@gmail.com
-copyright:      2021-2023 Nathan Waivio
+copyright:      2021-2024 Nathan Waivio
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
@@ -17,7 +17,7 @@ tested-with:         GHC == 8.10.7,
                      GHC == 9.2.8,
                      GHC == 9.4.8,
                      GHC == 9.6.6,
-                     GHC == 9.8.3
+                     GHC == 9.8.4
   -- fails rewrite rules with ghc-9.6.3 bummer
   -- Things before ghc-8.10.7 fail, don't care! 
 

--- a/posit.cabal
+++ b/posit.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           posit
-version:        2022.2.0.0
+version:        2022.2.0.1
 category:       Numeric, Math
 description:    The Posit Number format attempting to conform to the Posit Standard Versions 3.2 and 2022.  Where Real numbers are approximated by `Maybe Rational` and sampled in a similar way to the projective real line.
 homepage:       https://github.com/waivio/posit#readme
@@ -16,7 +16,8 @@ tested-with:         GHC == 8.10.7,
                      GHC == 9.0.2,
                      GHC == 9.2.8,
                      GHC == 9.4.8,
-                     GHC == 9.6.3
+                     GHC == 9.6.6,
+                     GHC == 9.8.3
   -- fails rewrite rules with ghc-9.6.3 bummer
   -- Things before ghc-8.10.7 fail, don't care! 
 
@@ -65,7 +66,7 @@ library
     ghc-options: -fforce-recomp -ddump-rule-firings
 
   if flag(do-liquid)
-    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--fast -fplugin-opt=LiquidHaskell:--no-termination -fplugin-opt=LiquidHaskell:--max-case-expand=4 -fplugin-opt=LiquidHaskell:--short-names
+    -- ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--fast -fplugin-opt=LiquidHaskell:--no-termination -fplugin-opt=LiquidHaskell:--max-case-expand=4 -fplugin-opt=LiquidHaskell:--short-names
  
   if flag(do-no-storable-random)
     cpp-options: -DO_NO_STORABLE_RANDOM
@@ -88,8 +89,8 @@ library
  
   if flag(do-liquid)
     build-depends:
-      liquid-base,
-      liquidhaskell
+      -- liquid-base,
+      -- liquidhaskell
 
 -- perhaps one day: -threaded -rtsopts -with-rtsopts=-N
 test-suite posit-test
@@ -110,11 +111,11 @@ test-suite test-posit-functions
   main-is: TestElementaryFunctions.hs
   hs-source-dirs:
       test
-  ghc-options: -O2  -threaded -rtsopts -with-rtsopts=-N
-  cpp-options: -DO_REWRITE
+  ghc-options: -Wall -O2 -threaded -rtsopts "-with-rtsopts=-N13"
   build-depends:
     base >= 4.7 && < 5,
     posit >= 2022.0.1,
+    time >=1.0 && <2,
     Chart,
     Chart-cairo
   default-language: Haskell2010

--- a/src/Posit.hs
+++ b/src/Posit.hs
@@ -1,7 +1,7 @@
 
 --------------------------------------------------------------------------------------------
 --   Posit Numbers
---   Copyright   :  (C) 2022-2023 Nathan Waivio
+--   Copyright   :  (C) 2022-2024 Nathan Waivio
 --   License     :  BSD3
 --   Maintainer  :  Nathan Waivio <nathan.waivio@gmail.com>
 --   Stability   :  Stable

--- a/src/Posit.hs
+++ b/src/Posit.hs
@@ -139,7 +139,7 @@ import Data.Bits (shiftL, (.&.), (.|.))
 -- import Posit.Internal.ElementaryFunctions
 -- Perhaps on the chopping block if we are moving to ElementaryFunctions
 -- Imports for implementing the Transcendental Functions
-import GHC.Natural (Natural) -- Import the Natural Numbers ℕ (u+2115) for some of the Transcendental Functions
+import Numeric.Natural (Natural) -- Import the Natural Numbers ℕ (u+2115) for some of the Transcendental Functions
 import Data.Ratio ()  -- Import the Rational Numbers ℚ (u+211A), ℚ can get arbitrarily close to Real numbers ℝ (u+211D), used for some of the Transcendental Functions, no more (%) now.
 
 -- for NFData instance

--- a/src/Posit.hs
+++ b/src/Posit.hs
@@ -857,14 +857,14 @@ approx_cosh x = (approx_exp x + approx_exp (negate x))/2
 
 approx_asinh :: PositC es => Posit es -> Posit es
 approx_asinh NaR = NaR
-approx_asinh x = approx_log $ x + approx_sqrt (fma x x 1)  -- (x^2 + 1)
+approx_asinh x = approx_log $ x + approx_sqrt (fma x x 1)  -- (x^2 + 1)  -- 
 
 
 approx_acosh :: PositC es => Posit es -> Posit es
 approx_acosh NaR = NaR
 approx_acosh x
   | x < 1 = NaR
-  | otherwise = approx_log $ x + approx_sqrt (fma x x (-1))  -- (x^2 - 1)
+  | otherwise = approx_log $ x + approx_sqrt (fma x x (-1))  -- (x^2 - 1)  -- 
 
 
 approx_atanh :: forall es. PositC es => Posit es -> Posit es

--- a/src/Posit/Internal/PositC.hs
+++ b/src/Posit/Internal/PositC.hs
@@ -67,7 +67,7 @@ import Data.Bits (Bits(..), shiftL, shiftR, testBit, (.&.), FiniteBits)
 
 -- Import Naturals and Rationals
 {-@ embed Natural * as int @-}
-import GHC.Natural (Natural) -- Import the Natural Numbers ℕ (u+2115)
+import Numeric.Natural (Natural) -- Import the Natural Numbers ℕ (u+2115)
 {-@ embed Ratio * as real @-}
 {-@ embed Rational * as real @-}
 import Data.Ratio ((%))  -- Import the Rational Numbers ℚ (u+211A), ℚ can get arbitrarily close to Real numbers ℝ (u+211D)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
 # This file is attempting to maintain the working Liquid Haskell versions
 # that coorispond to a specific GHC or Stackage version
 
-resolver: nightly-2024-12-08 # ghc-9.8.4
-# resolver: nightly-2024-11-23 # ghc-9.8.3
+# resolver: nightly-2024-12-18 # ghc-9.10.1
+resolver: lts-23.1 # ghc-9.8.4
 # resolver: lts-22.42 # ghc-9.6.6
 # resolver: lts-21.25 # ghc-9.4.8
 # resolver: lts-20.26 # ghc-9.2.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,10 @@
 # This file is attempting to maintain the working Liquid Haskell versions
 # that coorispond to a specific GHC or Stackage version
 
-# resolver: nightly-2023-10-16  # ghc-9.6.3
-resolver: lts-21.22 # ghc-9.4.8
-# resolver: lts-21.19 # ghc-9.4.7
+resolver: nightly-2024-12-08 # ghc-9.8.4
+# resolver: nightly-2024-11-23 # ghc-9.8.3
+# resolver: lts-22.42 # ghc-9.6.6
+# resolver: lts-21.25 # ghc-9.4.8
 # resolver: lts-20.26 # ghc-9.2.8
 # resolver: lts-19.33 # ghc-9.0.2
 # resolver: lts-18.28 # ghc-8.10.7
@@ -15,32 +16,33 @@ packages:
 allow-newer: true
 extra-deps:
   # For Test
-  - Chart-1.9.4
-  - Chart-cairo-1.9.3
-  - cairo-0.13.10.0
+  - Chart-1.9.5
+  - Chart-cairo-1.9.4.1
+  - cairo-0.13.11.0
+  - gtk2hs-buildtools-0.13.11.0
   # For LiquidHaskell:
   # - hashable-1.3.5.0 # lts-20.16 and below
-  - hashable-1.4.2.0 # ghc-9.4.4
-  - text-format-0.3.2
-  - Diff-0.3.4
-  - optparse-applicative-0.16.1.0
+  # - hashable-1.4.2.0 # ghc-9.4.4
+  # - text-format-0.3.2
+  # - Diff-0.3.4
+  # - optparse-applicative-0.18.1.0
   # - rest-rewrite-0.3.0 # ye olde reliable
-  - rest-rewrite-0.4.1 # latest
-  - smtlib-backends-0.3 # ghc-9.2.7
-  - smtlib-backends-process-0.3 # ghc-9.2.7
-  - git: https://github.com/ucsd-progsys/liquidhaskell 
-    # commit: <something> # ghc-9.4.4 "Generically" errors out! Ambiguous occurrence ‘Generically’: It could refer to... ‘GHC.Generics.Generically’ or 'Language.Haskell.Liquid.Types.Generics.Generically'
-    commit: 63337d432b47c1ba1ec9925db0994fc5cdce3eaf # ghc-9.2.7
+  # - rest-rewrite-0.4.1 # latest
+  # - smtlib-backends-0.3 # ghc-9.2.7
+  # - smtlib-backends-process-0.3 # ghc-9.2.7
+  # - git: https://github.com/ucsd-progsys/liquidhaskell 
+  #   # commit: <something> # ghc-9.4.4 "Generically" errors out! Ambiguous occurrence ‘Generically’: It could refer to... ‘GHC.Generics.Generically’ or 'Language.Haskell.Liquid.Types.Generics.Generically'
+  #   commit: 63337d432b47c1ba1ec9925db0994fc5cdce3eaf # ghc-9.2.7
     # commit: b8780ee8d73d123adb39675ef87a2883f8aa1ecd # ghc-9.0.2
     # commit: f917323a1f9db1677e592d6ffc81467d53588d70 # ghc-8.10.7
-    subdirs:
-      - .
-      - liquid-base
-      - liquid-vector
-      - liquid-bytestring
-      - liquid-containers
-      - liquid-ghc-prim 
-  - git: https://github.com/ucsd-progsys/liquid-fixpoint
-    commit: 0e1a4725793740f495c26957044c56488d6e1efc # ghc-9.2.7
+  #   subdirs:
+  #     - .
+  #     - liquid-base
+  #     - liquid-vector
+  #     - liquid-bytestring
+  #     - liquid-containers
+  #     - liquid-ghc-prim 
+  # - git: https://github.com/ucsd-progsys/liquid-fixpoint
+  #   commit: 0e1a4725793740f495c26957044c56488d6e1efc # ghc-9.2.7
     # commit: 5aed39ec3210b9093ed635693d01bf351e25392f # ghc-9.0.2
     # commit: 544f8b0ba6d03b060701961250cce012412039c4 # ghc-8.10.7

--- a/test/Test/Algorithms.hs
+++ b/test/Test/Algorithms.hs
@@ -40,7 +40,7 @@ import Prelude hiding (rem)
 -- import Posit.Internal.ElementaryFunctions
 -- Perhaps on the chopping block if we are moving to ElementaryFunctions
 -- Imports for implementing the Transcendental Functions
-import GHC.Natural (Natural) -- Import the Natural Numbers ℕ (u+2115) for some of the Transcendental Functions
+import Numeric.Natural (Natural) -- Import the Natural Numbers ℕ (u+2115) for some of the Transcendental Functions
 import Data.Ratio ((%))  -- Import the Rational Numbers ℚ (u+211A), ℚ can get arbitrarily close to Real numbers ℝ (u+211D), used for some of the Transcendental Functions
 
 

--- a/test/TestElementaryFunctions.hs
+++ b/test/TestElementaryFunctions.hs
@@ -13,21 +13,63 @@ import Graphics.Rendering.Chart.Easy
 import Graphics.Rendering.Chart.Backend.Cairo
 
 
+import Control.Concurrent (forkFinally,newEmptyMVar,putMVar,tryTakeMVar,MVar)
+import Data.Maybe (catMaybes)
+
+import Data.Time.Clock (getCurrentTime)
+
 main :: IO ()
-main = do expPlotP16Posit16
-          logPlotP16Posit16
-          sqrtPlotsP16Posit16
-          sinPlotsP16Posit16
-          cosPlotsP16Posit16
-          asinPlotsP16Posit16
-          acosPlotsP16Posit16
-          atanPlotsP16Posit16
-          sinhPlotsP16Posit16
-          coshPlotsP16Posit16
-          asinhPlotsP16Posit16
-          acoshPlotsP16Posit16
-          atanhPlotsP16Posit16
+main = do
+  print "Start:"
+  print =<< getCurrentTime
+  mvar1 <- newEmptyMVar
+  mvar2 <- newEmptyMVar
+  mvar3 <- newEmptyMVar
+  mvar4 <- newEmptyMVar
+  mvar5 <- newEmptyMVar
+  mvar6 <- newEmptyMVar
+  mvar7 <- newEmptyMVar
+  mvar8 <- newEmptyMVar
+  mvar9 <- newEmptyMVar
+  mvar10 <- newEmptyMVar
+  mvar11 <- newEmptyMVar
+  mvar12 <- newEmptyMVar
+  mvar13 <- newEmptyMVar
+  forkFinally expPlotP16Posit16 (\_ -> printDone mvar1 "exp")
+  forkFinally logPlotP16Posit16 (\_ -> printDone mvar2 "log")
+  forkFinally sqrtPlotsP16Posit16 (\_ -> printDone mvar3 "sqrt")
+  forkFinally sinPlotsP16Posit16 (\_ -> printDone mvar4 "sin")
+  forkFinally cosPlotsP16Posit16 (\_ -> printDone mvar5 "cos")
+  forkFinally asinPlotsP16Posit16 (\_ -> printDone mvar6 "asin")
+  forkFinally acosPlotsP16Posit16 (\_ -> printDone mvar7 "acos")
+  forkFinally atanPlotsP16Posit16 (\_ -> printDone mvar8 "atan")
+  forkFinally sinhPlotsP16Posit16 (\_ -> printDone mvar9 "sinh")
+  forkFinally coshPlotsP16Posit16 (\_ -> printDone mvar10 "cosh")
+  forkFinally asinhPlotsP16Posit16 (\_ -> printDone mvar11 "asinh")
+  forkFinally acoshPlotsP16Posit16 (\_ -> printDone mvar12 "acosh")
+  forkFinally atanhPlotsP16Posit16 (\_ -> printDone mvar13 "atanh")
+  checkToSeeIfDone [mvar1,mvar2,mvar3,mvar4,mvar5,mvar6,mvar7,mvar8,mvar9,mvar10,mvar11,mvar12,mvar13]
 --
+
+checkToSeeIfDone :: [MVar ()] -> IO ()
+checkToSeeIfDone [] = return ()
+checkToSeeIfDone mvars = do
+  listMaybeMVars <- mapM filtDone mvars
+  checkToSeeIfDone (catMaybes listMaybeMVars)
+
+
+filtDone :: MVar () -> IO (Maybe (MVar ()))
+filtDone mvar = do
+  r <- tryTakeMVar mvar
+  case r of
+    Nothing -> return $ Just mvar
+    Just _ -> return $ Nothing
+
+printDone mvar str = do
+  t <- getCurrentTime
+  putStrLn $ "Completed " ++ str ++ " at: " ++ show t
+  putMVar mvar ()
+
 
 expPlotP16Posit16 = toFile def "./test/Results/Bits Accuracy of exp with P16 and Posit16.png" $ do
     let expP16 = filter (\(_,d) -> not $ nanOrInf d) [(read (displayIntegral p) :: Double, err p (exp p) exp) | p <- enumFrom (NaR :: P16)]


### PR DESCRIPTION
Replaced GHC.Natural with Numeric.Natural.  GHC.Natural is internal and libraries that would like stability guarantees should use Numeric.Natural, so I updated that.

Refactored some of the tests to run in parallel, saving significant time.