### PR TITLE
Updated stack.yaml to support modern Liquid Haskell

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for Posit Numbers
 
+# posit.2022.2.0.2
+
+ * Fixed some of the `liquidhaskell` dependencies in the stack.yaml for your pleasure.
+ * For reminders to use LiquidHaskell support: stack build --flag posit:do-liquid
+
 # posit-2022.2.0.1
 
  * Replaced GHC.Natural with Numeric.Natural

--- a/posit.cabal
+++ b/posit.cabal
@@ -1,14 +1,14 @@
 cabal-version: 1.12
 
 name:           posit
-version:        2022.2.0.1
+version:        2022.2.0.2
 category:       Numeric, Math
 description:    The Posit Number format attempting to conform to the Posit Standard Versions 3.2 and 2022.  Where Real numbers are approximated by `Maybe Rational` and sampled in a similar way to the projective real line.
 homepage:       https://github.com/waivio/posit#readme
 bug-reports:    https://github.com/waivio/posit/issues
 author:         Nathan Waivio
 maintainer:     nathan.waivio@gmail.com
-copyright:      2021-2024 Nathan Waivio
+copyright:      2021-2025 Nathan Waivio
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
@@ -17,7 +17,8 @@ tested-with:         GHC == 8.10.7,
                      GHC == 9.2.8,
                      GHC == 9.4.8,
                      GHC == 9.6.6,
-                     GHC == 9.8.4
+                     GHC == 9.8.4,
+                     GHC == 9.10.1
   -- fails rewrite rules with ghc-9.6.3 bummer
   -- Things before ghc-8.10.7 fail, don't care! 
 
@@ -43,7 +44,7 @@ flag do-liquid
   default:     False
 
 flag do-rewrite
-  description: Build with Rewrite Rules for Fused Operations.
+  description: Build with Rewrite Rules for Fused Operations. Warning! this may not be deterministic between GHC releases.
   manual:      True
   default:     False
 
@@ -66,7 +67,7 @@ library
     ghc-options: -fforce-recomp -ddump-rule-firings
 
   if flag(do-liquid)
-    -- ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--fast -fplugin-opt=LiquidHaskell:--no-termination -fplugin-opt=LiquidHaskell:--max-case-expand=4 -fplugin-opt=LiquidHaskell:--short-names
+    ghc-options: -fplugin=LiquidHaskell -fplugin-opt=LiquidHaskell:--fast -fplugin-opt=LiquidHaskell:--no-termination -fplugin-opt=LiquidHaskell:--max-case-expand=4 -fplugin-opt=LiquidHaskell:--short-names
  
   if flag(do-no-storable-random)
     cpp-options: -DO_NO_STORABLE_RANDOM
@@ -75,13 +76,11 @@ library
     cpp-options: -DO_LIQUID -DO_NO_STORABLE_RANDOM
  
  
-  -- Other library packages from which modules are imported.
+  -- Other library packages from which modules are imported.  liquidhaskell doesn't need it's own version of base anymore.
   build-depends:
-    deepseq >=1.1 && <2
+    deepseq >=1.1 && <2,
+    base >=4.7 && <5
  
-  if !flag(do-liquid)
-    build-depends:
-      base >=4.7 && <5
  
   if !flag(do-no-storable-random)
     build-depends:
@@ -89,8 +88,7 @@ library
  
   if flag(do-liquid)
     build-depends:
-      -- liquid-base,
-      -- liquidhaskell
+      liquidhaskell
 
 -- perhaps one day: -threaded -rtsopts -with-rtsopts=-N
 test-suite posit-test

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,9 @@
 # This file is attempting to maintain the working Liquid Haskell versions
 # that coorispond to a specific GHC or Stackage version
 
-# resolver: nightly-2024-12-18 # ghc-9.10.1
-resolver: lts-23.1 # ghc-9.8.4
-# resolver: lts-22.42 # ghc-9.6.6
+resolver: nightly-2025-03-05 # ghc-9.10.1, you may need to upgrade stack to 3.1.1
+# resolver: lts-23.11 # ghc-9.8.4
+# resolver: lts-22.43 # ghc-9.6.6
 # resolver: lts-21.25 # ghc-9.4.8
 # resolver: lts-20.26 # ghc-9.2.8
 # resolver: lts-19.33 # ghc-9.0.2
@@ -21,28 +21,36 @@ extra-deps:
   - cairo-0.13.11.0
   - gtk2hs-buildtools-0.13.11.0
   # For LiquidHaskell:
-  # - hashable-1.3.5.0 # lts-20.16 and below
-  # - hashable-1.4.2.0 # ghc-9.4.4
-  # - text-format-0.3.2
-  # - Diff-0.3.4
-  # - optparse-applicative-0.18.1.0
-  # - rest-rewrite-0.3.0 # ye olde reliable
-  # - rest-rewrite-0.4.1 # latest
-  # - smtlib-backends-0.3 # ghc-9.2.7
-  # - smtlib-backends-process-0.3 # ghc-9.2.7
-  # - git: https://github.com/ucsd-progsys/liquidhaskell 
-  #   # commit: <something> # ghc-9.4.4 "Generically" errors out! Ambiguous occurrence ‘Generically’: It could refer to... ‘GHC.Generics.Generically’ or 'Language.Haskell.Liquid.Types.Generics.Generically'
-  #   commit: 63337d432b47c1ba1ec9925db0994fc5cdce3eaf # ghc-9.2.7
-    # commit: b8780ee8d73d123adb39675ef87a2883f8aa1ecd # ghc-9.0.2
-    # commit: f917323a1f9db1677e592d6ffc81467d53588d70 # ghc-8.10.7
-  #   subdirs:
-  #     - .
-  #     - liquid-base
-  #     - liquid-vector
-  #     - liquid-bytestring
-  #     - liquid-containers
-  #     - liquid-ghc-prim 
-  # - git: https://github.com/ucsd-progsys/liquid-fixpoint
-  #   commit: 0e1a4725793740f495c26957044c56488d6e1efc # ghc-9.2.7
-    # commit: 5aed39ec3210b9093ed635693d01bf351e25392f # ghc-9.0.2
-    # commit: 544f8b0ba6d03b060701961250cce012412039c4 # ghc-8.10.7
+  # ghc-9.10.1 should work with the new liquidhaskell-0.9.10.1, this actually works!
+  - liquidhaskell-0.9.10.1
+  - liquidhaskell-boot-0.9.10.1
+  - liquid-fixpoint-0.9.6.3.1
+  - smtlib-backends-0.4
+  - smtlib-backends-process-0.3
+  - ghc-internal-9.1001.0
+  # ghc-9.8.4 should work with the new liquidhaskell-0.9.8.1, both 0.9.8.1 and 0.9.8.2 seems broke
+  # - liquidhaskell-0.9.8.1
+  # - liquidhaskell-boot-0.9.8.1
+  # - liquid-fixpoint-0.9.6.3
+  # - smtlib-backends-0.4
+  # - smtlib-backends-process-0.3
+  # ghc-9.6.6 should work with the new liquidhaskell-0.9.6.3.1, this actually works!
+  # - liquidhaskell-0.9.6.3.1
+  # - liquidhaskell-boot-0.9.6.3
+  # - liquid-fixpoint-0.9.6.3
+  # - smtlib-backends-0.4
+  # - smtlib-backends-process-0.3
+  # ghc-9.4.8 should work with the new liquidhaskell-0.9.4.7.0, this actually works!
+  # - liquidhaskell-0.9.4.7.0
+  # - liquidhaskell-boot-0.9.4.7.0
+  # - liquid-fixpoint-0.9.4.7
+  # - smtlib-backends-0.4
+  # - smtlib-backends-process-0.3
+  # ghc-9.2.8 should work with the new liquidhaskell-0.9.2.8.0, this actually works!
+  # - liquidhaskell-0.9.2.8.0
+  # - liquidhaskell-boot-0.9.2.8.0
+  # - liquid-fixpoint-0.9.2.5
+  # - rest-rewrite-0.4.4
+  # - smtlib-backends-0.4
+  # - smtlib-backends-process-0.3
+


### PR DESCRIPTION
Updated stack.yaml for modern Liquid Haskell implementation.
Tested with ghc-9.10.1 as well, no changes needed for compatibility.

Good to go!