### PR TITLE
Updates to add a flag to enable warnings for overflow and underflow.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 # Changelog for Posit Numbers
 
-# posit.2022.2.0.2
+# posit-2022.2.0.3
+
+ * Added flag to warn if an overflow or underflow occurs
+ * To use the flag with GHCI for instance: stack repl --flag posit:warn-overflow-underflow
+ * If compiled with `-prof`, `-fprof-auto`, or `-fprof-auto-calls`, stack trace information will be added
+
+# posit-2022.2.0.2
 
  * Fixed some of the `liquidhaskell` dependencies in the stack.yaml for your pleasure.
  * For reminders to use LiquidHaskell support: stack build --flag posit:do-liquid

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# posit 2022.2.0.1
+# posit 2022.2
 
 The [Posit Standard 2022](https://posithub.org/docs/posit_standard-2.pdf),
 and [Posit Standard 3.2](https://posithub.org/docs/posit_standard.pdf), 

--- a/posit.cabal
+++ b/posit.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           posit
-version:        2022.2.0.2
+version:        2022.2.0.3
 category:       Numeric, Math
 description:    The Posit Number format attempting to conform to the Posit Standard Versions 3.2 and 2022.  Where Real numbers are approximated by `Maybe Rational` and sampled in a similar way to the projective real line.
 homepage:       https://github.com/waivio/posit#readme
@@ -48,6 +48,11 @@ flag do-rewrite
   manual:      True
   default:     False
 
+flag warn-overflow-underflow
+  description: Build with the option to emit warnings when an overflow or underflow occurs.
+  manual:      True
+  default:     False
+
 library
   exposed-modules:
       Posit
@@ -75,6 +80,8 @@ library
   if flag(do-liquid)
     cpp-options: -DO_LIQUID -DO_NO_STORABLE_RANDOM
  
+  if flag(warn-overflow-underflow)
+    cpp-options: -DO_WARN_OVER_UNDER_FLOW
  
   -- Other library packages from which modules are imported.  liquidhaskell doesn't need it's own version of base anymore.
   build-depends:

--- a/src/Posit.hs
+++ b/src/Posit.hs
@@ -1,7 +1,7 @@
 
 --------------------------------------------------------------------------------------------
 --   Posit Numbers
---   Copyright   :  (C) 2022-2024 Nathan Waivio
+--   Copyright   :  (C) 2022-2025 Nathan Waivio
 --   License     :  BSD3
 --   Maintainer  :  Nathan Waivio <nathan.waivio@gmail.com>
 --   Stability   :  Stable
@@ -838,7 +838,7 @@ approx_acos x
 approx_atan :: PositC es => Posit es -> Posit es
 approx_atan NaR = NaR
 approx_atan x
-  | abs x < 1/2^122 = x  -- small angle approximaiton, found emperically
+  | abs x < 1/2^122 = x  -- small angle approximaiton, found empirically
   | x < 0 = negate.approx_atan $ negate x  -- if negative turn it positive, it reduces the other domain reductions by half, found from Universal CORDIC
   | x > 1 = approx_pi/2 - approx_atan (recip x)  -- if larger than one use the complementary angle, found from Universal CORDIC
   | x > twoMsqrt3 = approx_pi/6 + approx_atan ((sqrt3 * x - 1)/(sqrt3 + x))  -- another domain reduction, using an identity, found from https://mathonweb.com/help_ebook/html/algorithms.htm

--- a/src/Posit/Internal/PositC.hs
+++ b/src/Posit/Internal/PositC.hs
@@ -1,7 +1,7 @@
 
 --------------------------------------------------------------------------------------------
 --
---   Copyright   :  (C) 2022-2023 Nathan Waivio
+--   Copyright   :  (C) 2022-2025 Nathan Waivio
 --   License     :  BSD3
 --   Maintainer  :  Nathan Waivio <nathan.waivio@gmail.com>
 --   Stability   :  Stable
@@ -72,6 +72,9 @@ import Numeric.Natural (Natural) -- Import the Natural Numbers ℕ (u+2115)
 {-@ embed Rational * as real @-}
 import Data.Ratio ((%))  -- Import the Rational Numbers ℚ (u+211A), ℚ can get arbitrarily close to Real numbers ℝ (u+211D)
 
+#ifdef O_WARN_OVER_UNDER_FLOW
+import Debug.Trace (traceStack)
+#endif
 
 -- | The Exponent Size 'ES' kind, the constructor for the Type is a Roman Numeral.
 data ES = Z_3_2
@@ -203,10 +206,17 @@ class (FixedWidthInteger (IntN es)) => PositC (es :: ES) where
   encode Nothing = unReal @es
   encode (Just 0) = 0
   encode (Just r)
+#ifdef O_WARN_OVER_UNDER_FLOW
+    | r > maxPosRat @es = traceStack "Warning! Overflow Occured" (mostPosVal @es)
+    | r < minNegRat @es = traceStack "Warning! Overflow Occured" (mostNegVal @es)
+    | r > 0 && r < minPosRat @es = traceStack "Warning! Underflow Occured" (leastPosVal @es)
+    | r < 0 && r > maxNegRat @es = traceStack "Warning! Underflow Occured" (leastNegVal @es)
+#else
     | r > maxPosRat @es = mostPosVal @es
     | r < minNegRat @es = mostNegVal @es
     | r > 0 && r < minPosRat @es = leastPosVal @es
     | r < 0 && r > maxNegRat @es = leastNegVal @es
+#endif
     | otherwise = buildIntRep @es r
   
   decode :: IntN es -> Maybe Rational  -- ^ You have an integer with a finite integer log2 word size decode it and Maybe it is Rational

--- a/src/Posit/Internal/PositC.hs
+++ b/src/Posit/Internal/PositC.hs
@@ -207,10 +207,10 @@ class (FixedWidthInteger (IntN es)) => PositC (es :: ES) where
   encode (Just 0) = 0
   encode (Just r)
 #ifdef O_WARN_OVER_UNDER_FLOW
-    | r > maxPosRat @es = traceStack "Warning! Overflow Occured" (mostPosVal @es)
-    | r < minNegRat @es = traceStack "Warning! Overflow Occured" (mostNegVal @es)
-    | r > 0 && r < minPosRat @es = traceStack "Warning! Underflow Occured" (leastPosVal @es)
-    | r < 0 && r > maxNegRat @es = traceStack "Warning! Underflow Occured" (leastNegVal @es)
+    | r > maxPosRat @es = traceStack "Warning! Overflow Occurred" (mostPosVal @es)
+    | r < minNegRat @es = traceStack "Warning! Overflow Occurred" (mostNegVal @es)
+    | r > 0 && r < minPosRat @es = traceStack "Warning! Underflow Occurred" (leastPosVal @es)
+    | r < 0 && r > maxNegRat @es = traceStack "Warning! Underflow Occurred" (leastNegVal @es)
 #else
     | r > maxPosRat @es = mostPosVal @es
     | r < minNegRat @es = mostNegVal @es

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # This file is attempting to maintain the working Liquid Haskell versions
 # that coorispond to a specific GHC or Stackage version
 
-resolver: nightly-2025-03-05 # ghc-9.10.1, you may need to upgrade stack to 3.1.1
+resolver: nightly-2025-04-23 # ghc-9.10.1, you may need to upgrade stack to 3.1.1
 # resolver: lts-23.11 # ghc-9.8.4
 # resolver: lts-22.43 # ghc-9.6.6
 # resolver: lts-21.25 # ghc-9.4.8


### PR DESCRIPTION
resolves #17 

Added flag to enable warning on overflow and underflow.

Example Usage:
`stack repl --flag posit:warn-overflow-underflow`

```
ghci> softmax x = map (/ sum exps) exps where exps = map exp x
ghci> sum $ softmax ([100000,200000,3000000] :: [Posit256])
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
Warning! Overflow Occurred
3.00000000000000000000000000000000000000000000000000000000000000000000000000000
```